### PR TITLE
Make RubyGems 3.7.1 and Bundler 2.7.1 the default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Issues are tracked at https://github.com/roberts1000/noble_docker_rde/issues. Ch
 1. [#62](../../issues/62): Sort aliases.
 1. [#64](../../issues/64): Add Ruby 3.4.5 as the default.
 1. [#66](../../issues/66): Remove Ruby 3.4.4.
+1. [#68](../../issues/68): Make `RubyGems` `3.7.1` and `Bundler` `2.7.1` the default.
 
 ## 1.4.0 (Jun 27, 2025)
 

--- a/build/scripts/setup_rvm_rubies
+++ b/build/scripts/setup_rvm_rubies
@@ -2,7 +2,7 @@
 
 # The first version in the list is set as the default Ruby in RVM.
 RUBIES_TO_INSTALL = ['3.4.5']
-RUBYGEMS_TO_INSTALL = '3.6.9'
+RUBYGEMS_TO_INSTALL = '3.7.1'
 
 RUBIES_TO_INSTALL.each do |version_string|
   puts "Installing Ruby #{version_string}"


### PR DESCRIPTION
<!-- Replace XYZ with a GitHub issue number. -->
<!-- A pull request should address a single issue. -->

Closes #68 
