### PR TITLE
Make RubyGems 3.7.2 and Bundler 2.7.2 the default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Issues are tracked at https://github.com/roberts1000/noble_docker_rde/issues. Ch
 ## Next Release
 
 1. [#76](../../issues/76): Make `NodeJS` `24.9.0` the default.
+1. [#78](../../issues/78): Make `RubyGems` `3.7.2` and `Bundler` `2.7.2` the default.
 
 ## 1.5.0 (Oct 06, 2025)
 

--- a/build/scripts/setup_rvm_rubies
+++ b/build/scripts/setup_rvm_rubies
@@ -2,7 +2,7 @@
 
 # The first version in the list is set as the default Ruby in RVM.
 RUBIES_TO_INSTALL = ['3.4.5']
-RUBYGEMS_TO_INSTALL = '3.7.1'
+RUBYGEMS_TO_INSTALL = '3.7.2'
 
 RUBIES_TO_INSTALL.each do |version_string|
   puts "Installing Ruby #{version_string}"


### PR DESCRIPTION
<!-- Replace XYZ with a GitHub issue number. -->
<!-- A pull request should address a single issue. -->

Closes #78 